### PR TITLE
Add simple Streamlit interface for IMDb sentiment

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ python main.py --mode train
 python main.py --mode eval
 ```
 
+### Run the Web App
+After training, you can launch a simple Streamlit interface to explore
+sentiment predictions for IMDb movies:
+
+```bash
+streamlit run app.py
+```
+
 ## Results
 Using the default configuration (5 epochs, embedding size 64), the model reaches about **86% accuracy** on the test set. The exact numbers may vary but should be in this range after several epochs of training.
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,44 @@
+import tensorflow as tf
+import streamlit as st
+from imdb import IMDb
+from src.data_loader import load_config, get_datasets, get_vectorize_layer
+
+@st.cache_resource
+def load_resources():
+    config = load_config()
+    train_data, _ = get_datasets(config)
+    vectorize_layer = get_vectorize_layer(config, train_data)
+    model = tf.keras.models.load_model(config['model_save_path'])
+    return model, vectorize_layer
+
+def fetch_reviews(title: str):
+    ia = IMDb()
+    results = ia.search_movie(title)
+    if not results:
+        return []
+    movie = results[0]
+    ia.update(movie, info=['reviews'])
+    reviews = movie.get('reviews', [])
+    return [r.get('content', '') for r in reviews]
+
+def main():
+    st.title('IMDb Review Sentiment')
+    model, vectorize_layer = load_resources()
+    movie_title = st.text_input('Enter a movie title')
+    if movie_title:
+        with st.spinner('Fetching reviews...'):
+            reviews = fetch_reviews(movie_title)
+        if not reviews:
+            st.warning('No reviews found for this movie.')
+        else:
+            inputs = tf.constant(reviews)
+            vectorized = vectorize_layer(inputs)
+            preds = model.predict(vectorized, verbose=0).flatten()
+            for rev, pred in zip(reviews, preds):
+                label = 'Positive' if pred >= 0.5 else 'Negative'
+                st.markdown(f'**{label} ({pred:.2f})** - {rev}')
+            pos_ratio = (preds >= 0.5).mean()
+            st.write(f'Overall positive ratio: {pos_ratio * 100:.2f}%')
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@
 tensorflow
 tensorflow-datasets
 pyyaml
+streamlit
+IMDbPY


### PR DESCRIPTION
## Summary
- add a Streamlit `app.py` that fetches IMDb reviews and predicts sentiment
- add `streamlit` and `IMDbPY` to requirements
- document how to launch the web app in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684b9daaf860832ca37a9adb68a6402d