### PR TITLE
Save vocabulary after fitting

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -19,3 +19,4 @@ learning_rate: 0.001
 # Paths
 model_save_path: outputs/models/sentiment_model.h5
 log_dir: outputs/logs
+vocab_path: outputs/vocab.txt

--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,5 +1,6 @@
 # src/data_loader.py
 
+import os
 import tensorflow as tf
 import tensorflow_datasets as tfds
 import yaml
@@ -42,3 +43,18 @@ def vectorize_dataset(dataset, vectorize_layer):
         return vectorize_layer(text), label
 
     return dataset.map(vectorize_text)
+
+
+def save_vocabulary(vectorize_layer, filepath):
+    """Save the vocabulary from a TextVectorization layer."""
+    os.makedirs(os.path.dirname(filepath), exist_ok=True)
+    vocab = vectorize_layer.get_vocabulary()
+    with open(filepath, 'w') as f:
+        for token in vocab:
+            f.write(token + '\n')
+
+
+def load_vocabulary(filepath):
+    """Load a vocabulary file into a Python list."""
+    with open(filepath, 'r') as f:
+        return [line.strip() for line in f]

--- a/src/train.py
+++ b/src/train.py
@@ -2,7 +2,13 @@
 
 import os
 import tensorflow as tf
-from src.data_loader import load_config, get_datasets, get_vectorize_layer, vectorize_dataset
+from src.data_loader import (
+    load_config,
+    get_datasets,
+    get_vectorize_layer,
+    vectorize_dataset,
+    save_vocabulary,
+)
 from src.model import build_lstm_model
 
 def train():
@@ -11,6 +17,7 @@ def train():
     # Load and preprocess datasets
     train_data, test_data = get_datasets(config)
     vectorize_layer = get_vectorize_layer(config, train_data)
+    save_vocabulary(vectorize_layer, config.get('vocab_path', 'outputs/vocab.txt'))
     train_data = vectorize_dataset(train_data, vectorize_layer)
     test_data = vectorize_dataset(test_data, vectorize_layer)
 


### PR DESCRIPTION
## Summary
- save vocabulary from the `TextVectorization` layer
- expose vocabulary path in `config.yaml`
- persist vocabulary when running training

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684ba5515ac0832c8780ba158a69ea17