### PR TITLE
Use saved vocabulary for predictions

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,19 @@
 import tensorflow as tf
+from tensorflow.keras.layers import TextVectorization
 import streamlit as st
 from imdb import IMDb
-from src.data_loader import load_config, get_datasets, get_vectorize_layer
+from src.data_loader import load_config, load_vocabulary
 
 @st.cache_resource
 def load_resources():
     config = load_config()
-    train_data, _ = get_datasets(config)
-    vectorize_layer = get_vectorize_layer(config, train_data)
+    vocab = load_vocabulary(config.get('vocab_path', 'outputs/vocab.txt'))
+    vectorize_layer = TextVectorization(
+        max_tokens=config['vocab_size'],
+        output_mode='int',
+        output_sequence_length=config['sequence_length'],
+    )
+    vectorize_layer.set_vocabulary(vocab)
     model = tf.keras.models.load_model(config['model_save_path'])
     return model, vectorize_layer
 

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -1,14 +1,29 @@
 # src/evaluate.py
 
 import tensorflow as tf
-from src.data_loader import load_config, get_datasets, get_vectorize_layer, vectorize_dataset
+from tensorflow.keras.layers import TextVectorization
+from src.data_loader import (
+    load_config,
+    get_datasets,
+    vectorize_dataset,
+    load_vocabulary,
+)
 
 def evaluate():
     config = load_config()
 
     # Load and preprocess test data
     _, test_data = get_datasets(config)
-    vectorize_layer = get_vectorize_layer(config, test_data)  # Use test data just to adapt layer
+
+    # Recreate vectorization layer using the saved vocabulary
+    vocab = load_vocabulary(config.get('vocab_path', 'outputs/vocab.txt'))
+    vectorize_layer = TextVectorization(
+        max_tokens=config['vocab_size'],
+        output_mode='int',
+        output_sequence_length=config['sequence_length'],
+    )
+    vectorize_layer.set_vocabulary(vocab)
+
     test_data = vectorize_dataset(test_data, vectorize_layer)
 
     # Load the best model


### PR DESCRIPTION
## Summary
- avoid adapting the vectorizer when running evaluation or the app
- rebuild `TextVectorization` with `set_vocabulary()`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt` *(fails: aborted due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_684ba5f72fc0832cbecc5d45f2a1bbe7